### PR TITLE
Adding pinned version of Java 1.8 to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Had an issue compiling in Eclipse where it kept falling back to Java v1.5 even though v1.8 is installed. Due to issue described here:
https://stackoverflow.com/a/47731675

Pinning to v1.8 in the pom.xml fixed compile issue and passed tests!