### PR TITLE
Add delete method in DataSet class

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,41 @@ BATS, the Basic Artifact Tracking System (BATS), is a simple data management ser
 ### Prerequisites
 
 BATS requires a full installation of Docker for building, executing, and storing images.
+See below section "Running BATS with Docker" for how to use BATS with Docker.
 
 ### Detailed Build Instructions
 
 See each subfolder for build instructions.
+
+
+### Running BATS with Docker
+
+The following are available Docker utilities for BATS
+
+####  Quickstart w/ docker-compose
+
+You can spin up BATS with a Fuseki backend service using [docker-compose](https://docs.docker.com/compose/) via:
+
+```
+docker-compose build
+docker-compose up
+```
+
+Spin down the containers via:
+
+```
+docker-compose down
+```
+
+#### Running Tests w/ docker-compose
+
+To run the test suite, run:
+
+```
+docker-compose -f docker-compose.test.yml build
+docker-compose -f docker-compose.test.yml run bats mvn test
+docker-compose -f docker-compose.test.yml down
+```
 
 ## How BATS got its name
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  fuseki:
+    build:
+      context: ./dockerfiles
+      dockerfile: Dockerfile.fuseki
+    network_mode: "host"
+    ports:
+      - "3030:3030"
+    volumes:
+      - /opt/fuseki-TDB:/data/TDB
+
+  bats:
+    build:
+      context: ./
+      dockerfile: ./dockerfiles/Dockerfile.bats.test
+    network_mode: "host"
+    ports:
+      - "8080:8080"
+    depends_on: 
+       - fuseki

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,14 @@ services:
     ports:
     - "3030:3030"
     volumes:
-    - fuseki-TDB:/data/TDB:Z
-volumes:
-  fuseki-TDB: {}
+      - /opt/fuseki-TDB:/data/TDB
+
+  bats:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.bats
+    network_mode: "host"
+    ports:
+      - "8080:8080"
+    depends_on:
+      - fuseki

--- a/dockerfiles/Dockerfile.bats
+++ b/dockerfiles/Dockerfile.bats
@@ -1,0 +1,10 @@
+FROM maven:3.6-jdk-11 AS build
+COPY pom.xml /home/app/pom.xml
+RUN mvn -f /home/app/pom.xml verify clean --fail-never
+COPY src /home/app/src
+RUN mvn -f /home/app/pom.xml package -Dmaven.test.skip=true
+
+FROM openjdk:11-jre-slim
+VOLUME /tmp 
+COPY --from=build /home/app/target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/dockerfiles/Dockerfile.bats.test
+++ b/dockerfiles/Dockerfile.bats.test
@@ -1,0 +1,6 @@
+FROM maven:3.6-jdk-11
+COPY pom.xml /home/app/pom.xml
+RUN mvn -f /home/app/pom.xml verify clean --fail-never
+COPY src /home/app/src
+WORKDIR /home/app
+CMD ["mvn", "test"]

--- a/dockerfiles/Dockerfile.fuseki
+++ b/dockerfiles/Dockerfile.fuseki
@@ -1,8 +1,20 @@
 FROM openjdk:11.0.1-jre
-MAINTAINER Jay Jay Billings (billingsjj@ornl.gov)
+  
+# Specify Fuseki variables
+ARG FUSEKI_VERSION=3.16.0
+ARG FUSEKI_NAME=apache-jena-fuseki
+ARG FUSEKI_DOWNLOAD_FILE=$FUSEKI_NAME-$FUSEKI_VERSION.tar.gz
 
-# Copy the Fuseki tar ball if it is on the local file system and automatically expand it.
-COPY apache-jena-fuseki /opt/apache-jena-fuseki
+# Install Fuseki
+RUN wget https://www-us.apache.org/dist/jena/binaries/$FUSEKI_DOWNLOAD_FILE && \
+    tar -xzvf $FUSEKI_DOWNLOAD_FILE && \
+    mv $FUSEKI_NAME-$FUSEKI_VERSION /opt/$FUSEKI_NAME && \
+    mkdir -p /opt/$FUSEKI_NAME/run/configuration
+
+
+# Add dataset turtle to fuseki config and shiro.ini  for security config
+ADD dataset.ttl /opt/$FUSEKI_NAME/run/configuration/dataset.ttl
+ADD shiro.ini /opt/$FUSEKI_NAME/run/shiro.ini
 
 # Expose the Fuseki port
 EXPOSE 3030
@@ -10,3 +22,4 @@ EXPOSE 3030
 # Execute Fuseki from the installation directory
 WORKDIR /opt/apache-jena-fuseki
 ENTRYPOINT ["./fuseki-server"]
+

--- a/dockerfiles/shiro.ini
+++ b/dockerfiles/shiro.ini
@@ -1,0 +1,52 @@
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+[main]
+# Development
+ssl.enabled = false
+
+plainMatcher=org.apache.shiro.authc.credential.SimpleCredentialsMatcher
+#iniRealm=org.apache.shiro.realm.text.IniRealm
+iniRealm.credentialsMatcher = $plainMatcher
+
+#localhost=org.apache.jena.fuseki.authz.LocalhostFilter
+
+[users]
+# Implicitly adds "iniRealm =  org.apache.shiro.realm.text.IniRealm"
+admin=pw
+
+[roles]
+
+[urls]
+## Control functions open to anyone
+/$/status = anon
+/$/ping   = anon
+
+## and the rest are restricted
+/$/** = authcBasic,user[admin]
+
+
+## If you want simple, basic authentication user/password
+## on the operations,
+##    1 - set a password in [users]
+##    2 - change the line above to:
+## /$/** = authcBasic,user[admin]
+## and set a better
+
+## or to allow any access.
+/$/** = anon
+
+# Everything else
+/**=anon

--- a/src/main/java/gov/ornl/rse/bats/DataSet.java
+++ b/src/main/java/gov/ornl/rse/bats/DataSet.java
@@ -200,6 +200,8 @@ public class DataSet {
 
     /**
      * This operation deletes the data set with the given name.
+     *
+     * @throws Exception
      */
     public void delete() throws Exception {
 		// Connect the HTTP client

--- a/src/main/java/gov/ornl/rse/bats/DataSet.java
+++ b/src/main/java/gov/ornl/rse/bats/DataSet.java
@@ -211,8 +211,6 @@ public class DataSet {
 			// Note that transactions must proceed with begin(), some operation(), and
 			// commit().
 			uploadConn.begin(ReadWrite.WRITE);
-			System.out.println(model.toString());
-//			uploadConn.load(modelName, model);
 			uploadConn.put(modelName, model);
 			uploadConn.commit();
 			logger.debug("Committed model " + modelName + " to data set" + getName());

--- a/src/main/java/gov/ornl/rse/bats/DataSet.java
+++ b/src/main/java/gov/ornl/rse/bats/DataSet.java
@@ -19,6 +19,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
@@ -81,6 +82,14 @@ public class DataSet {
 	 * The default name for a dataset.
 	 */
 	private String name = DEFAULT_NAME;
+
+    private String configureName() {
+		String dbName = DEFAULT_NAME;
+		if (name == DEFAULT_NAME) {
+			name += "_" + UUID.randomUUID().toString();
+		}
+		return name;
+    }
 
 	/**
 	 * This operation sets the name of the data set. The name of the data set is the
@@ -163,13 +172,9 @@ public class DataSet {
 	 *                   for any reason.
 	 */
 	public void create() throws Exception {
+        // Configure name
+        String dbName = configureName();
 
-		// Configure the name
-		String dbName = DEFAULT_NAME;
-		if (name == DEFAULT_NAME) {
-			name += "_" + UUID.randomUUID().toString();
-		}
-		dbName = name;
 		// Per the spec, always use tdb2.
 		String dbType = "tdb2";
 
@@ -192,6 +197,23 @@ public class DataSet {
 
 		return;
 	}
+
+    /**
+     * This operation deletes the data set with the given name.
+     */
+    public void delete() throws Exception {
+		// Connect the HTTP client
+		HttpClient client = HttpClientBuilder.create().build();
+		String fusekiLocation = host + ":" + port + "/";
+		String fusekiDataAPILoc = "$/datasets/" + name;
+		HttpDelete delete = new HttpDelete((fusekiLocation + fusekiDataAPILoc));
+
+        // Delete the data set
+        HttpResponse response = client.execute(delete);
+        logger.debug(response.toString());
+
+        return;
+    }
 
 	/**
 	 * This operation directs the data set to update and persist any remotely stored

--- a/src/test/java/gov/ornl/rse/tests/bats/DataSetTest.java
+++ b/src/test/java/gov/ornl/rse/tests/bats/DataSetTest.java
@@ -120,17 +120,21 @@ public class DataSetTest {
 
     /**
      * This operation checks data set deletion
+     * 
+	 * @throws Exception this exception is thrown from getJenaDataset since
+     *                   we are unable to find the dataset after we delete it
      */
     @Test
-    public void testDelete() {
+    public void testDelete() throws Exception {
         // Create a default, empty data set with the default name
 		DataSet dataSet = new DataSet();
 		// Check the data set creation
 		checkDataSetCreationOnServer(dataSet);
 
-        // Delete the dataset here
-        // dataset.delete();
+        // Delete the dataset
+        dataSet.delete();
 
+        // Check that we get null back from the dataset
         Dataset contents = dataSet.getJenaDataset();
         System.out.println(contents);
         assertNull(contents);

--- a/src/test/java/gov/ornl/rse/tests/bats/DataSetTest.java
+++ b/src/test/java/gov/ornl/rse/tests/bats/DataSetTest.java
@@ -10,7 +10,11 @@
  *****************************************************************************/
 package gov.ornl.rse.tests.bats;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import java.util.UUID;
 
@@ -113,6 +117,24 @@ public class DataSetTest {
 
 		return;
 	}
+
+    /**
+     * This operation checks data set deletion
+     */
+    @Test
+    public void testDelete() {
+        // Create a default, empty data set with the default name
+		DataSet dataSet = new DataSet();
+		// Check the data set creation
+		checkDataSetCreationOnServer(dataSet);
+
+        // Delete the dataset here
+        // dataset.delete();
+
+        Dataset contents = dataSet.getJenaDataset();
+        System.out.println(contents);
+        assertNull(contents);
+    }
 
 	/**
 	 * This operation tries to pull some models from the data set


### PR DESCRIPTION
Work includes:
 - Adding the `delete` method to the BATS DataSet class to delete an entire dataset in Fuseki + test
 - Modifies the docker setup to include a `bats` service with `fuseki` service in docker-compose
 - Adds Dockerfile and docker-compose.test.yml to run the `mvn test` in docker with fuseki
 - Adds an [Apache Shiro](https://shiro.apache.org/) file for the Fuseki setup for "wide open" security (i.e. none) for development
 - Updates to README
